### PR TITLE
Move Encode Examples out of data model.

### DIFF
--- a/src/extensions/epigenomics/Encode.ttl
+++ b/src/extensions/epigenomics/Encode.ttl
@@ -5,10 +5,11 @@
 # prefix: Encode
 
 @prefix : <http://datamodel.terra.bio/Encode#> .
-@prefix DSPCore: <http://datamodel.terra.bio#> .
+@prefix DSPCore: <http://datamodel.terra.bio/DSPCore#> .
 @prefix DSPdcat_ap: <http://datamodel.terra.bio/DSPdcat_ap#> .
 @prefix Encode: <http://datamodel.terra.bio/Encode#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -17,10 +18,6 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-DSPCore:Experiment
-  DSPCore:hasAssay Encode:OBI_0002142_1 ;
-  DSPCore:hasSponsor "\"http://www.encodeproject.org/awards/U54HG006998/\"" ;
-.
 DSPCore:File
   Encode:hasDataQuality "{\"orange\",\"red\",\"white\",\"yellow\"}" ;
 .
@@ -44,205 +41,10 @@ DSPCore:hasEthnicity
   owl:imports <http://datamodel.terra.bio/OBI_ontofox.owl> ;
   owl:versionInfo "Created with TopBraid Composer" ;
 .
-Encode:Age_1
-  a DSPCore:Age ;
-  DSPCore:hasAgeCategory "Postnatal" ;
-  DSPCore:hasLowerBound "54"^^xsd:decimal ;
-  DSPCore:hasUnit "years" ;
-  DSPCore:hasUpperBound "54"^^xsd:decimal ;
-  rdfs:label "Age_1" ;
-  skos:prefLabel "Age_1" ;
-.
-Encode:Assay_for_ENCSR895SFC
-  a <http://datamodel.terra.bio/DSPCore#AssayActivity> ;
-  <http://datamodel.terra.bio/DSPCore#hasAssayType> Encode:OBI_0002142_1 ;
-  <http://datamodel.terra.bio/DSPCore#hasProtocol> "https://www.encodeproject.org/documents/d90ef931-e735-4b25-a7f8-6ddbcaea71dd/@@download/attachment/NanoString%20miRNA%20Assay.pdf" ;
-  <http://datamodel.terra.bio/DSPCore#hasTarget> "http://www.encodeproject.org/targets/STAT5A-human/" ;
-  Encode:hasAlias "ali-mortazavi: human-adrenal-gland-ENTEX51-52-nanostring" ;
-  rdfs:label "Assay_for_ENCSR895SFC" ;
-  prov:generated Encode:ENCFF488IYR ;
-  prov:generated Encode:ENCFF660GHH ;
-  prov:used Encode:ENCLB011GAL ;
-.
-Encode:ENCBS562VSE
-  a <http://datamodel.terra.bio/DSPCore#BioSample> ;
-  DSPCore:dateObtained "2015-10-30T00:00:00"^^xsd:dateTime ;
-  DSPCore:derived Encode:ENCBS719AMH ;
-  DSPCore:donatedBy Encode:ENCD0451RUA ;
-  DSPCore:hasAnatomicSite "UBERON:0002369" ;
-  DSPCore:hasBioSampleType <http://datamodel.broadinstitute.org/DSPCoreValueSets#Tissue> ;
-  DSPCore:hasConsentCode DSPCore:NoRestriction ;
-  dcterms:source "http://www.encodeproject.org/sources/kristin-ardlie/" ;
-  rdfs:label "ENCBS562VSE" ;
-  skos:prefLabel "ENCBS562VSE" ;
-.
-Encode:ENCBS719AMH
-  a <http://datamodel.terra.bio/DSPCore#BioSample> ;
-  DSPCore:derivedFrom Encode:ENCBS562VSE ;
-  DSPCore:donatedBy Encode:ENCD0451RUA ;
-  DSPCore:hasBioSampleType "tissue" ;
-  DSPCore:hasCrossReference "http://www.encodeproject.org/biosamples/ENCBS719AMH"^^dcterms:URI ;
-  DSPCore:hasReplicationType "isogenic" ;
-  DSPCore:hasResultFile Encode:ENCFF043TPA ;
-  DSPCore:hasResultFile Encode:ENCFF147BDY ;
-  DSPCore:hasResultFile Encode:ENCFF213BVA ;
-  DSPCore:hasResultFile Encode:ENCFF424QYJ ;
-  DSPCore:hasResultFile Encode:ENCFF488IYR ;
-  DSPCore:hasResultFile Encode:ENCFF660GHH ;
-  DSPCore:hasSponsor "\"http://www.encodeproject.org/awards/U54HG006998/\"" ;
-  DSPCore:usedBy Encode:ENCSR895SFC ;
-  DSPdcat_ap:hasPrimaryConsent DSPCore:NoRestriction ;
-  Encode:hasAlias "ali-mortazavi: human-adrenal-gland-ENTEX52-rep2" ;
-  Encode:hasAlias "gtex: ENC-1K2DA-016-SM-9JLPP" ;
-  Encode:hasBiologicalReplicateID 2 ;
-  Encode:hasLab "http://www.encodeproject.org/labs/barbara-wold/" ;
-  Encode:hasLibrary Encode:ENCLB011GAL ;
-  Encode:hasStatus "released" ;
-  Encode:hasTechnicalReplicateID 1 ;
-  Encode:submittedBy "http://www.encodeproject.org/users/bc5b62f7-ce28-4a1e-b6b3-81c9c5a86d7a/" ;
-  dcterms:created "2015-11-25T22:04:52.325534+00:00"^^xsd:dateTime ;
-  rdfs:label "ENCBS719AMH" ;
-  skos:prefLabel "ENCBS719AMH" ;
-.
-Encode:ENCD0451RUA
-  a <http://datamodel.terra.bio/DSPCore#Human> ;
-  DSPCore:donated Encode:ENCBS562VSE ;
-  DSPCore:hasAge Encode:Age_1 ;
-  DSPCore:hasCrossReference "http://www.encodeproject.org/human-donors/ENCDO451RUA/"^^dcterms:URI ;
-  DSPCore:hasOrganism DSPCore:Homo_sapiens ;
-  DSPCore:hasSex "Male" ;
-  Encode:hasAlias "GEO: SAMN05897789" ;
-  Encode:hasAlias "bradley-bernstein:Donor GTEX-1K2DA" ;
-  Encode:hasAlias "gtex:ENC-002" ;
-  Encode:hasAlias "gtex:ENC-LQT" ;
-  Encode:hasAlias "gtex:PT-1K2DA" ;
-  Encode:hasLab "http://www.encodeproject.org/labs/encode-consortium/" ;
-  Encode:lifeStage "adult" ;
-  dcterms:created "2015-02-14T00:31:58.584355+00:00" ;
-  rdfs:label "ENCD0451RUA" ;
-  skos:prefLabel "ENCD0451RUA" ;
-.
-Encode:ENCFF043TPA
-  a <http://datamodel.terra.bio/DSPCore#File> ;
-  DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF043TPA/"^^dcterms:URI ;
-  DSPCore:hasFormat "bidBed" ;
-  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
-  rdfs:label "ENCFF043TPA" ;
-  skos:prefLabel "ENCFF043TPA" ;
-.
-Encode:ENCFF147BDY
-  a <http://datamodel.terra.bio/DSPCore#File> ;
-  DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF147BDY/"^^dcterms:URI ;
-  DSPCore:hasFormat "bidBed" ;
-  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
-  rdfs:label "ENCFF147BDY" ;
-  skos:prefLabel "ENCFF147BDY" ;
-.
-Encode:ENCFF213BVA
-  a <http://datamodel.terra.bio/DSPCore#File> ;
-  DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF213BVA/"^^dcterms:URI ;
-  DSPCore:hasFormat "bed" ;
-  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
-  rdfs:label "ENCFF213BVA" ;
-  skos:prefLabel "ENCFF213BVA" ;
-.
-Encode:ENCFF424QYJ
-  a <http://datamodel.terra.bio/DSPCore#File> ;
-  DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF424QYJ/"^^dcterms:URI ;
-  DSPCore:hasFormat "bed" ;
-  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
-  rdfs:label "ENCFF424QYJ" ;
-  skos:prefLabel "ENCFF424QYJ" ;
-.
-Encode:ENCFF488IYR
-  a <http://datamodel.terra.bio/DSPCore#File> ;
-  DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF488IYR/"^^dcterms:URI ;
-  DSPCore:hasFormat "rcc" ;
-  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
-  rdfs:label "ENCFF488IYR" ;
-  skos:prefLabel "ENCFF488IYR" ;
-.
-Encode:ENCFF660GHH
-  a <http://datamodel.terra.bio/DSPCore#File> ;
-  DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF660GHH/"^^dcterms:URI ;
-  DSPCore:hasFormat "rcc" ;
-  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
-  rdfs:label "ENCFF660GHH" ;
-  skos:prefLabel "ENCFF660GHH" ;
-.
-Encode:ENCLB011GAL
-  a DSPCore:Library ;
-  DSPCore:hasCrossReference "http://www.encodeproject.org/libraries/ENCLB011GAL/"^^dcterms:URI ;
-  Encode:hasAlias "ali-mortazavi: human-adrenal-gland-ENTEX52-Lib2" ;
-  Encode:hasLab "http://www.encodeproject.org/labs/ali-mortazavi/" ;
-  Encode:strandSpecificity false ;
-  Encode:submittedBy "http://www.encodeproject.org/users/bc5b62f7-ce28-4a1e-b6b3-81c9c5a86d7a/" ;
-  dcterms:created "2016-07-25T22:17:41.258151+00:00" ;
-  rdfs:label "ENCLB011GAL" ;
-  skos:prefLabel "ENCLB011GAL" ;
-.
-Encode:ENCSR895SFC
-  a Encode:Experiment ;
-  DSPCore:dateReleased "2016-08-01T00:00:00"^^xsd:dateTime ;
-  DSPCore:hasCrossReference "http://www.encodeproject.org/experiments/ENCSR895SFC"^^dcterms:URI ;
-  DSPCore:usesSample Encode:ENCBS719AMH ;
-  <http://datamodel.terra.bio/DSPCore#hasAssay> Encode:Assay_for_ENCSR895SFC ;
-  Encode:hasLibrary Encode:ENCLB011GAL ;
-  Encode:hasStatus "released" ;
-  dcterms:created "2016-07-25T22:17:18.167352+00" ;
-  dcterms:dateSubmitted "2016-07-31" ;
-  rdfs:label "ENCSR895SFC" ;
-  skos:prefLabel "ENCSR895SFC" ;
-  prov:hadActivity Encode:MortazaviLab_NanoStringPipeline ;
-  prov:used Encode:ENCBS719AMH ;
-.
-Encode:EncodeDataset
-  a DSPdcat_ap:Dataset ;
-  DSPdcat_ap:hasPrimaryConsent DSPCore:NoRestriction ;
-  dcterms:hasPart Encode:ENCBS562VSE ;
-  dcterms:hasPart Encode:ENCBS719AMH ;
-  dcterms:hasPart Encode:ENCD0451RUA ;
-  rdfs:label "EncodeDataset" ;
-  skos:prefLabel "EncodeDataset" ;
-.
 Encode:Experiment
   a owl:Class ;
   rdfs:label "Experiment" ;
   rdfs:subClassOf <http://datamodel.terra.bio/DSPCore#Activity> ;
-.
-Encode:MortazaviLab_NanoStringPipeline
-  a <http://datamodel.terra.bio/DSPCore#Pipeline> ;
-  <http://datamodel.terra.bio/DSPCore#hasProtocol> "https://www.encodeproject.org/documents/01810c91-4873-4268-b6a4-7e3e7c620fe0/@@download/attachment/nanostring_pipeline_overview_V1.png" ;
-  rdfs:label "Pipeline" ;
-  prov:generated Encode:ENCFF043TPA ;
-  prov:generated Encode:ENCFF147BDY ;
-  prov:generated Encode:ENCFF213BVA ;
-  prov:generated Encode:ENCFF424QYJ ;
-  prov:used Encode:ENCFF488IYR ;
-  prov:used Encode:ENCFF660GHH ;
-.
-Encode:OBI_0002142_1
-  a obo:OBI_0002142 ;
-  rdfs:label "Nanostring nCounter miRNA expression assay" ;
-  skos:prefLabel "Nanostring nCounter miRNA expression assay" ;
-  prov:generated Encode:ENCFF043TPA ;
-  prov:generated Encode:ENCFF147BDY ;
-  prov:generated Encode:ENCFF213BVA ;
-  prov:generated Encode:ENCFF424QYJ ;
-  prov:generated Encode:ENCFF488IYR ;
-  prov:generated Encode:ENCFF660GHH ;
-.
-Encode:hasAlias
-  a owl:AnnotationProperty ;
-  rdfs:domain DSPCore:BioSample ;
-  rdfs:domain DSPCore:Donor ;
-  rdfs:domain DSPCore:Experiment ;
-  rdfs:domain DSPCore:Library ;
-  rdfs:domain DSPCore:LibraryPrep ;
-  rdfs:label "hasAlias" ;
-  rdfs:range xsd:string ;
-  rdfs:subPropertyOf skos:altLabel ;
-  skos:prefLabel "hasAlias" ;
 .
 Encode:hasBiologicalReplicateID
   a owl:DatatypeProperty ;
@@ -270,14 +72,14 @@ Encode:hasLab
 .
 Encode:hasLibrary
   a owl:ObjectProperty ;
-  rdfs:domain <http://datamodel.terra.bio/DSPCore#BioSample> ;
+  rdfs:domain DSPCore:BioSample ;
   rdfs:domain Encode:Experiment ;
   rdfs:label "hasLibrary" ;
-  rdfs:range <http://datamodel.terra.bio/DSPCore#Library> ;
+  rdfs:range DSPCore:Library ;
 .
 Encode:hasReplicateID
   a owl:DatatypeProperty ;
-  rdfs:domain <http://datamodel.terra.bio/DSPCore#BioSample> ;
+  rdfs:domain DSPCore:BioSample ;
   rdfs:label "hasReplicateID" ;
   rdfs:range xsd:integer ;
 .
@@ -335,3 +137,4 @@ Encode:submittedBy
   rdfs:range xsd:string ;
   skos:prefLabel "submittedBy" ;
 .
+

--- a/src/extensions/epigenomics/EncodeExamples.ttl
+++ b/src/extensions/epigenomics/EncodeExamples.ttl
@@ -1,0 +1,336 @@
+# baseURI: http://data.broadinstitute.org/EncodeExamples
+# imports: http://datamodel.terra.bio/DSPCore
+# imports: http://datamodel.terra.bio/Encode
+# prefix: EncodeExamples
+
+@prefix : <http://data.broadinstitute.org/EncodeExamples#> .
+@prefix DSPCore: <http://datamodel.terra.bio/DSPCore#> .
+@prefix DSPdcat_ap: <http://datamodel.terra.bio/DSPdcat_ap#> .
+@prefix Encode: <http://datamodel.terra.bio/Encode#> .
+@prefix EncodeExamples: <http://data.broadinstitute.org/EncodeExamples#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix epiLIMS: <http://data.terra.bio/epiLIMS#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://data.broadinstitute.org/EncodeExamples>
+  a owl:Ontology ;
+  owl:imports <http://datamodel.terra.bio/DSPCore> ;
+  owl:imports <http://datamodel.terra.bio/Encode> ;
+  owl:versionInfo "Created with TopBraid Composer" ;
+.
+EncodeExamples:Age_1
+  a <http://datamodel.terra.bio#Age> ;
+  <http://datamodel.terra.bio#hasAgeCategory> "Postnatal" ;
+  <http://datamodel.terra.bio#hasLowerBound> "54"^^xsd:decimal ;
+  <http://datamodel.terra.bio#hasUnit> "years" ;
+  <http://datamodel.terra.bio#hasUpperBound> "54"^^xsd:decimal ;
+  rdfs:label "Age_1" ;
+  skos:prefLabel "Age_1" ;
+.
+EncodeExamples:Age_2-4day
+  a DSPCore:Age ;
+  DSPCore:hasAgeCategory "Postnatal" ;
+  DSPCore:hasAgeUnit "days" ;
+  DSPCore:hasLowerBound "2"^^xsd:decimal ;
+  DSPCore:hasUpperBound "4"^^xsd:decimal ;
+  rdfs:label "2-4 day" ;
+.
+EncodeExamples:Anti-CTCF_Antibody
+  a DSPCore:Antibody ;
+  rdfs:label "Anti-CTCF Antibody" ;
+.
+EncodeExamples:Assay_for_ENCSR895SFC
+  a DSPCore:AssayActivity ;
+  <http://datamodel.terra.bio#hasCrossReference> "ali-mortazavi: human-adrenal-gland-ENTEX51-52-nanostring" ;
+  DSPCore:hasAssayCategory "Transcription" ;
+  DSPCore:hasAssayType Encode:OBI_0002142_1 ;
+  DSPCore:hasProtocol "https://www.encodeproject.org/documents/d90ef931-e735-4b25-a7f8-6ddbcaea71dd/@@download/attachment/NanoString%20miRNA%20Assay.pdf" ;
+  DSPCore:hasTarget "http://www.encodeproject.org/targets/STAT5A-human/"^^xsd:anyURI ;
+  rdfs:label "Assay_for_ENCSR895SFC" ;
+  prov:generated EncodeExamples:ENCFF488IYR ;
+  prov:generated Encode:ENCFF660GHH ;
+  prov:used EncodeExamples:ENCLB011GAL ;
+.
+EncodeExamples:Award_Encode
+  a Encode:Grant ;
+  rdfs:label "Award_Encode" ;
+  dcat:accessURL <http://datamodel.terra.bio/www.encodeproject.org/awards/ENCODE> ;
+.
+EncodeExamples:DataCollection_EncodeEpiLIMS
+  a DSPdcat_ap:DataCollection ;
+  DSPdcat_ap:hasDataset EncodeExamples:EncodeDataset ;
+  DSPdcat_ap:hasDataset epiLIMS:EpiLIMS ;
+  dcterms:title "Encode and Epigenomics Lab Data Demonstration Data Collection" ;
+  rdfs:label "DataCollection_EncodeEpiLIMS" ;
+  skos:prefLabel "DataCollection_EncodeEpiLIMS" ;
+.
+EncodeExamples:ENCBS143WXN
+  a DSPCore:BioSample ;
+  DSPCore:hasBioSampleType <http://datamodel.broadinstitute.org/DSPCoreValueSets#Tissue> ;
+  rdfs:label "ENCBS143WXN" ;
+.
+EncodeExamples:ENCBS389AUD
+  a DSPCore:BioSample ;
+  DSPCore:dateObtained "2015-11-10T00:00:00"^^xsd:dateTime ;
+  DSPCore:hasBioSampleType <http://datamodel.broadinstitute.org/DSPCoreValueSets#PrimaryCell> ;
+  DSPCore:hasCrossReference "http://www.encodeproject.org/biosamples/ENCBS389AUD/"^^dcterms:URI ;
+  Encode:hasAward "http://www.encodeproject.org/awards/U01HG007919/"^^xsd:anyURI ;
+  Encode:hasBioSampleTypeOntology "http://purl.obolibrary.org/obo/CL_100166"^^dcterms:URI ;
+  Encode:hasHealthStatus "Healthy" ;
+  Encode:hasLab "/labs/paul-khavari/" ;
+  Encode:hasReplicationType "anisogenic" ;
+  Encode:hasStatus "released" ;
+  Encode:hasTreatment "http://encodeproject.org/treatments/8815ea26-a0e7-4617-9e8b-a81df87ff2bd/" ;
+  Encode:wasPerturbed true ;
+  dcterms:created "2016-11-30T00:47:27.158916+00:00" ;
+  dcterms:source "/sources/paul-khavari/" ;
+  rdfs:label "ENCBS389AUD" ;
+  prov:wasUsedBy EncodeExamples:ENCSR812FNU ;
+.
+EncodeExamples:ENCBS562VSE
+  a DSPCore:BioSample ;
+  EncodeExamples:wasPerturbed false ;
+  <http://datamodel.terra.bio#dateObtained> "2015-10-30T00:00:00"^^xsd:dateTime ;
+  <http://datamodel.terra.bio#derived> EncodeExamples:ENCBS719AMH ;
+  <http://datamodel.terra.bio#donatedBy> EncodeExamples:ENCD0451RUA ;
+  <http://datamodel.terra.bio#hasAnatomicSite> "UBERON:0002369" ;
+  <http://datamodel.terra.bio#hasBioSampleType> <http://datamodel.broadinstitute.org/DSPCoreValueSets#Tissue> ;
+  <http://datamodel.terra.bio#hasConsentCode> <http://datamodel.terra.bio#NoRestriction> ;
+  dcterms:source "http://www.encodeproject.org/sources/kristin-ardlie/" ;
+  rdfs:label "ENCBS562VSE" ;
+  skos:prefLabel "ENCBS562VSE" ;
+.
+EncodeExamples:ENCBS719AMH
+  a DSPCore:BioSample ;
+  <http://datamodel.terra.bio#derivedFrom> EncodeExamples:ENCBS562VSE ;
+  <http://datamodel.terra.bio#donatedBy> EncodeExamples:ENCD0451RUA ;
+  <http://datamodel.terra.bio#hasAward> "\"http://www.encodeproject.org/awards/U54HG006998/\"" ;
+  <http://datamodel.terra.bio#hasCrossReference> "ali-mortazavi: human-adrenal-gland-ENTEX52-rep2" ;
+  <http://datamodel.terra.bio#hasCrossReference> "gtex: ENC-1K2DA-016-SM-9JLPP" ;
+  <http://datamodel.terra.bio#hasCrossReference> "http://www.encodeproject.org/biosamples/ENCBS719AMH"^^dcterms:URI ;
+  <http://datamodel.terra.bio#hasResultFile> EncodeExamples:ENCFF043TPA ;
+  <http://datamodel.terra.bio#hasResultFile> EncodeExamples:ENCFF147BDY ;
+  <http://datamodel.terra.bio#hasResultFile> EncodeExamples:ENCFF213BVA ;
+  <http://datamodel.terra.bio#hasResultFile> EncodeExamples:ENCFF424QYJ ;
+  <http://datamodel.terra.bio#hasResultFile> EncodeExamples:ENCFF488IYR ;
+  <http://datamodel.terra.bio#hasResultFile> EncodeExamples:ENCFF660GHH ;
+  <http://datamodel.terra.bio#usedBy> EncodeExamples:ENCSR895SFC ;
+  DSPCore:hasAssay EncodeExamples:Assay_for_ENCSR895SFC ;
+  DSPCore:hasBioSampleType <http://datamodel.broadinstitute.org/DSPCoreValueSets#Tissue> ;
+  DSPCore:hasLibraryPrep EncodeExamples:LibraryPrep_for_ENCSR895SFC ;
+  DSPdcat_ap:hasDataUseLimitation <http://datamodel.terra.bio#NoRestriction> ;
+  Encode:hasBiologicalReplicateID 2 ;
+  Encode:hasReplicationType "isogenic" ;
+  Encode:hasStatus "released" ;
+  Encode:hasTechnicalReplicateID 1 ;
+  Encode:submittedBy "http://www.encodeproject.org/users/bc5b62f7-ce28-4a1e-b6b3-81c9c5a86d7a/"^^xsd:anyURI ;
+  Encode:wasPerturbed false ;
+  dcterms:created "2015-11-25T22:04:52.325534+00:00"^^xsd:dateTime ;
+  rdfs:label "ENCBS719AMH" ;
+  skos:prefLabel "ENCBS719AMH" ;
+  prov:hadActivity EncodeExamples:MortazaviLab_NanoStringPipeline ;
+  prov:wasAttributedTo "http://www.encodeproject.org/labs/barbara-wold/" ;
+.
+EncodeExamples:ENCD0451RUA
+  a DSPCore:HumanDonor ;
+  <http://datamodel.terra.bio#donated> EncodeExamples:ENCBS562VSE ;
+  <http://datamodel.terra.bio#hasAge> EncodeExamples:Age_1 ;
+  <http://datamodel.terra.bio#hasCrossReference> "GEO: SAMN05897789" ;
+  <http://datamodel.terra.bio#hasCrossReference> "bradley-bernstein:Donor GTEX-1K2DA" ;
+  <http://datamodel.terra.bio#hasCrossReference> "gtex:ENC-002" ;
+  <http://datamodel.terra.bio#hasCrossReference> "gtex:ENC-LQT" ;
+  <http://datamodel.terra.bio#hasCrossReference> "gtex:PT-1K2DA" ;
+  <http://datamodel.terra.bio#hasCrossReference> "http://www.encodeproject.org/human-donors/ENCDO451RUA/"^^dcterms:URI ;
+  <http://datamodel.terra.bio#hasOrganism> DSPCore:Homo_sapiens ;
+  Encode:hasLifeStage "adult" ;
+  dcterms:created "2015-02-14T00:31:58.584355+00:00" ;
+  rdfs:label "ENCD0451RUA" ;
+  skos:prefLabel "ENCD0451RUA" ;
+  prov:wasAttributedTo "http://www.encodeproject.org/labs/encode-consortium/" ;
+.
+EncodeExamples:ENCDO615NVN
+  a DSPCore:HumanDonor ;
+  DSPCore:donated EncodeExamples:ENCBS389AUD ;
+  DSPCore:hasAge EncodeExamples:Age_2-4day ;
+  DSPCore:hasCrossReference "http://encodeproject.org/human-donors/ENCDO615NVN/"^^dcterms:URI ;
+  DSPCore:hasOrganism DSPCore:Homo_sapiens ;
+  DSPCore:hasSex DSPCore:Male ;
+  Encode:hasAward "http://encodeproject.org/awards/U01HG007919/"^^xsd:anyURI ;
+  Encode:hasHealthStatus "Healthy" ;
+  Encode:hasLab "http://encodeproject.org/labs/paul-khavari/"^^xsd:anyURI ;
+  Encode:hasLifeStage "newborn" ;
+  Encode:submittedBy "http://encodeproject.org/users/37d5e120-ea80-4f13-8096-1f132e424ca1/"^^xsd:anyURI ;
+  dcterms:created "2016-07-30T22:48:18.369918+00:00" ;
+  dcterms:isPartOf EncodeExamples:EncodeDataset ;
+  rdfs:label "ENCDO615NVN" ;
+.
+EncodeExamples:ENCFF005SHK
+  a DSPCore:File ;
+  DSPCore:hasDataModality <http://datamodel.broadinstitute.org/DSPCoreValueSets#WholeGenome> ;
+  DSPCore:hasFormat "fastq" ;
+  rdfs:label "ENCFF005SHK" ;
+.
+EncodeExamples:ENCFF043TPA
+  a DSPCore:File ;
+  <http://datamodel.terra.bio#hasCrossReference> "https://www.encodeproject.org/files/ENCFF043TPA/"^^dcterms:URI ;
+  <http://datamodel.terra.bio#hasFormat> "bidBed" ;
+  DSPCore:hasDataModality <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
+  rdfs:label "ENCFF043TPA" ;
+  skos:prefLabel "ENCFF043TPA" ;
+.
+EncodeExamples:ENCFF147BDY
+  a DSPCore:File ;
+  <http://datamodel.terra.bio#hasCrossReference> "https://www.encodeproject.org/files/ENCFF147BDY/"^^dcterms:URI ;
+  <http://datamodel.terra.bio#hasFormat> "bidBed" ;
+  DSPCore:hasDataModality <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
+  rdfs:label "ENCFF147BDY" ;
+  skos:prefLabel "ENCFF147BDY" ;
+.
+EncodeExamples:ENCFF213BVA
+  a DSPCore:File ;
+  <http://datamodel.terra.bio#hasCrossReference> "https://www.encodeproject.org/files/ENCFF213BVA/"^^dcterms:URI ;
+  <http://datamodel.terra.bio#hasFormat> "bed" ;
+  DSPCore:hasDataModality <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
+  rdfs:label "ENCFF213BVA" ;
+  skos:prefLabel "ENCFF213BVA" ;
+.
+EncodeExamples:ENCFF424QYJ
+  a DSPCore:File ;
+  <http://datamodel.terra.bio#hasCrossReference> "https://www.encodeproject.org/files/ENCFF424QYJ/"^^dcterms:URI ;
+  <http://datamodel.terra.bio#hasFormat> "bed" ;
+  DSPCore:hasDataModality <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
+  rdfs:label "ENCFF424QYJ" ;
+  skos:prefLabel "ENCFF424QYJ" ;
+.
+EncodeExamples:ENCFF488IYR
+  a DSPCore:File ;
+  <http://datamodel.terra.bio#hasCrossReference> "https://www.encodeproject.org/files/ENCFF488IYR/"^^dcterms:URI ;
+  <http://datamodel.terra.bio#hasFormat> "rcc" ;
+  DSPCore:hasDataModality <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
+  rdfs:label "ENCFF488IYR" ;
+  skos:prefLabel "ENCFF488IYR" ;
+.
+EncodeExamples:ENCFF660GHH
+  a DSPCore:File ;
+  <http://datamodel.terra.bio#hasCrossReference> "https://www.encodeproject.org/files/ENCFF660GHH/"^^dcterms:URI ;
+  <http://datamodel.terra.bio#hasFormat> "rcc" ;
+  DSPCore:hasDataModality <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
+  rdfs:label "ENCFF660GHH" ;
+  skos:prefLabel "ENCFF660GHH" ;
+.
+EncodeExamples:ENCLB011GAL
+  a DSPCore:Library ;
+  <http://datamodel.terra.bio#hasCrossReference> "ali-mortazavi: human-adrenal-gland-ENTEX52-Lib2" ;
+  <http://datamodel.terra.bio#hasCrossReference> "http://www.encodeproject.org/libraries/ENCLB011GAL/"^^dcterms:URI ;
+  Encode:hasStrandSpecificity false ;
+  Encode:submittedBy "http://www.encodeproject.org/users/bc5b62f7-ce28-4a1e-b6b3-81c9c5a86d7a/"^^xsd:anyURI ;
+  dcterms:created "2016-07-25T22:17:41.258151+00:00" ;
+  rdfs:label "ENCLB011GAL" ;
+  skos:prefLabel "ENCLB011GAL" ;
+.
+EncodeExamples:ENCLB134JON
+  a DSPCore:Library ;
+  rdfs:label "ENCLB134JON" ;
+.
+EncodeExamples:ENCSR463NAD
+  a Encode:Experiment ;
+  rdfs:label "ENCSR463NAD" ;
+.
+EncodeExamples:ENCSR812FNU
+  a Encode:Experiment ;
+  DSPCore:usesSample EncodeExamples:ENCBS389AUD ;
+  Encode:hasAward "http://encodeproject.org/awards/U01HG007919"^^xsd:anyURI ;
+  Encode:hasLab "http://encodeproject.org/awards/michael-snyder"^^xsd:anyURI ;
+  dcterms:description "CTCF ChIP-seq on primary keratinocytes in day 6 of differentiation" ;
+  rdfs:label "ENCSR812FNU" ;
+.
+EncodeExamples:ENCSR895SFC
+  a Encode:Experiment ;
+  <http://datamodel.terra.bio#dateReleased> "2016-08-01T00:00:00"^^xsd:dateTime ;
+  <http://datamodel.terra.bio#hasCrossReference> "http://www.encodeproject.org/experiments/ENCSR895SFC"^^dcterms:URI ;
+  <http://datamodel.terra.bio#usesSample> EncodeExamples:ENCBS719AMH ;
+  Encode:hasStatus "released" ;
+  dcterms:created "2016-07-25T22:17:18.167352+00" ;
+  dcterms:dateSubmitted "2016-07-31" ;
+  dcterms:description "\"Nanostring miRNA Array on human adrenal gland\"" ;
+  rdfs:label "ENCSR895SFC" ;
+  skos:prefLabel "ENCSR895SFC" ;
+.
+EncodeExamples:EncodeDataset
+  a DSPdcat_ap:Dataset ;
+  DSPdcat_ap:hasDataUseLimitation <http://datamodel.terra.bio#NoRestriction> ;
+  dcterms:conformsTo <http://datamodel.terra.bio/DSPCore> ;
+  dcterms:hasPart EncodeExamples:ENCBS562VSE ;
+  dcterms:hasPart EncodeExamples:ENCBS719AMH ;
+  dcterms:hasPart EncodeExamples:ENCD0451RUA ;
+  rdfs:label "Encode Dataset at Broad Institute" ;
+  skos:prefLabel "EncodeDataset" ;
+.
+EncodeExamples:LibraryPrep_for_ENCSR895SFC
+  a DSPCore:LibraryPrep ;
+  rdfs:label "LibraryPrep_for_ENCSR895SFC" ;
+  prov:generated EncodeExamples:ENCLB011GAL ;
+.
+EncodeExamples:MissingControlledBy
+  a Encode:AuditFinding ;
+  Encode:hasLevelName "WARNING" ;
+  Encode:wasFoundIn EncodeExamples:ENCFF005SHK ;
+  Encode:wasFoundIn EncodeExamples:ENCSR463NAD ;
+  dcterms:description "controlled_by is a list of files that are used as controls for a given experimental file. Fastq files generated in a ChIP-seq assay require the specification of control fastq file(s) in the controlled_by list. Fastq file {ENCFF005SHK|/files/ENCFF005SHK/} is missing the requisite file specification in controlled_by list." ;
+  rdfs:label "Missing Controlled By" ;
+  prov:value "40" ;
+.
+EncodeExamples:MortazaviLab_NanoStringPipeline
+  a DSPCore:Pipeline ;
+  DSPCore:hasProtocol "https://www.encodeproject.org/documents/01810c91-4873-4268-b6a4-7e3e7c620fe0/@@download/attachment/nanostring_pipeline_overview_V1.png" ;
+  rdfs:label "Pipeline" ;
+  prov:generated EncodeExamples:ENCFF043TPA ;
+  prov:generated EncodeExamples:ENCFF147BDY ;
+  prov:generated EncodeExamples:ENCFF213BVA ;
+  prov:generated EncodeExamples:ENCFF424QYJ ;
+  prov:used EncodeExamples:ENCFF488IYR ;
+  prov:used EncodeExamples:ENCFF660GHH ;
+.
+EncodeExamples:OBI_0002142_1
+  a obo:OBI_0002142 ;
+  rdfs:label "Nanostring nCounter miRNA expression assay" ;
+  skos:prefLabel "Nanostring nCounter miRNA expression assay" ;
+  prov:generated EncodeExamples:ENCFF043TPA ;
+  prov:generated EncodeExamples:ENCFF147BDY ;
+  prov:generated EncodeExamples:ENCFF213BVA ;
+  prov:generated EncodeExamples:ENCFF424QYJ ;
+  prov:generated EncodeExamples:ENCFF488IYR ;
+  prov:generated EncodeExamples:ENCFF660GHH ;
+.
+EncodeExamples:U54HG006996
+  a Encode:Grant ;
+  rdfs:label "U54HG006996" ;
+  dcat:accessURL <http://datamodel.terra.bio/www.encodeproject.org/awards/U54HG006996> ;
+.
+EncodeExamples:U54HG006998
+  a Encode:Grant ;
+  rdfs:label "U54HG006998" ;
+  dcat:accessURL <http://datamodel.terra.bio/www.encodeproject.org/awards/U54HG006998> ;
+.
+<http://datamodel.terra.bio#Experiment>
+  <http://datamodel.terra.bio#hasAssay> Encode:OBI_0002142_1 ;
+  Encode:hasAward "\"http://www.encodeproject.org/awards/U54HG006998/\"" ;
+.
+<http://datamodel.terra.bio#Library>
+  Encode:hasAward "\"http://www.encodeproject.org/awards/U54HG006998/\"" ;
+.
+DSPCore:usedReferenceAssembly
+  rdfs:domain DSPCore:Alignment ;
+.
+Encode:wasFoundIn
+  rdfs:range DSPCore:Activity ;
+  rdfs:range DSPCore:Antibody ;
+  rdfs:range DSPCore:File ;
+.


### PR DESCRIPTION
In Encode.ttl, removed all examples and fixed a couple of prefixes.

In EncodeExamples.ttl, added new examples in addition to those removed from Encode.ttl.

(This will make the next pull request easier to review.)