### PR TITLE
Propagate recent cleanup to Encode

### DIFF
--- a/src/core/DSPCoreDataModel.ttl
+++ b/src/core/DSPCoreDataModel.ttl
@@ -1,10 +1,9 @@
 # baseURI: http://datamodel.terra.bio/DSPCore
 # imports: http://datamodel.terra.bio/DSPCoreValueSets
 # imports: http://datamodel.terra.bio/DSPdcat_ap
-# imports: http://datamodel.terra.bio/OBI_Taxon_Organisms.owl
 # imports: http://datamodel.terra.bio/OBI_assaySubset.owl
+# imports: http://datamodel.terra.bio/OBI_core
 # imports: http://purl.obolibrary.org/obo/
-# imports: http://purl.obolibrary.org/obo/PATO_0001340
 # imports: http://www.w3.org/2002/07/owl
 # imports: http://xmlns.com/foaf/0.1/
 # prefix: DSPCore
@@ -39,10 +38,9 @@
   a owl:Ontology ;
   owl:imports <http://datamodel.terra.bio/DSPCoreValueSets> ;
   owl:imports <http://datamodel.terra.bio/DSPdcat_ap> ;
-  owl:imports <http://datamodel.terra.bio/OBI_Taxon_Organisms.owl> ;
   owl:imports <http://datamodel.terra.bio/OBI_assaySubset.owl> ;
+  owl:imports <http://datamodel.terra.bio/OBI_core> ;
   owl:imports obo: ;
-  owl:imports obo:PATO_0001340 ;
   owl:imports <http://www.w3.org/2002/07/owl> ;
   owl:imports <http://xmlns.com/foaf/0.1/> ;
   owl:versionInfo "Created with TopBraid Composer" ;
@@ -74,7 +72,7 @@ DSPCore:Activity
   owl:equivalentClass [
       a owl:Restriction ;
       owl:minCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:usesSample ;
+      owl:onProperty DSPCore:usedSample ;
     ] ;
   owl:equivalentClass [
       a owl:Restriction ;
@@ -143,6 +141,11 @@ DSPCore:Alignment
   owl:disjointWith DSPCore:VariantCalling ;
   owl:equivalentClass [
       a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty DSPCore:usedReferenceAssembly ;
+    ] ;
+  owl:equivalentClass [
+      a owl:Restriction ;
       owl:onProperty prov:generated ;
       owl:someValuesFrom DSPCore:AlignmentFile ;
     ] ;
@@ -150,6 +153,11 @@ DSPCore:Alignment
       a owl:Restriction ;
       owl:onProperty prov:used ;
       owl:someValuesFrom DSPCore:SequenceFile ;
+    ] ;
+  owl:equivalentClass [
+      a owl:Restriction ;
+      owl:onProperty prov:used ;
+      owl:someValuesFrom prov:SoftwareAgent ;
     ] ;
   skos:prefLabel "Alignment" ;
   prov:definition "An activity that aligns the output of a Sequencing Activity (a genetic sequence) to produce an aligned sequence." ;
@@ -163,12 +171,17 @@ DSPCore:AlignmentFile
       owl:cardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty DSPCore:usedReferenceAssembly ;
     ] ;
+  owl:equivalentClass [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty DSPCore:hasPercentAlignedReads ;
+    ] ;
   skos:prefLabel "AlignmentFile" ;
 .
 DSPCore:AlignmentPostProcessing
   a owl:Class ;
   rdfs:label "AlignmentPostProcessing" ;
-  rdfs:subClassOf DSPCore:Activity ;
+  rdfs:subClassOf DSPCore:Pipeline ;
   owl:disjointWith DSPCore:Alignment ;
   owl:disjointWith DSPCore:AssayActivity ;
   owl:disjointWith DSPCore:LibraryPrep ;
@@ -184,6 +197,11 @@ DSPCore:AlignmentPostProcessing
       a owl:Restriction ;
       owl:onProperty prov:used ;
       owl:someValuesFrom DSPCore:AlignmentFile ;
+    ] ;
+  owl:equivalentClass [
+      a owl:Restriction ;
+      owl:onProperty prov:used ;
+      owl:someValuesFrom prov:SoftwareAgent ;
     ] ;
   skos:prefLabel "AlignmentPostProcessing" ;
   prov:definition "An activity that further processed the output of an Alignment Activity on a genetic sequence." ;
@@ -238,11 +256,6 @@ DSPCore:AssayActivity
       owl:onProperty prov:generated ;
       owl:someValuesFrom DSPCore:File ;
     ] ;
-  owl:equivalentClass [
-      a owl:Restriction ;
-      owl:onProperty prov:generated ;
-      owl:someValuesFrom DSPCore:Library ;
-    ] ;
   skos:prefLabel "Assay" ;
   prov:definition "An activity that generates an electronic record documenting the result of the Assay performed." ;
 .
@@ -251,6 +264,11 @@ DSPCore:BioSample
   dc:identifier "DSPCore:BioSample" ;
   rdfs:label "BioSample" ;
   rdfs:subClassOf DSPCore:Sample ;
+  owl:equivalentClass [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty DSPCore:hasBioSampleType ;
+    ] ;
   owl:equivalentClass [
       a owl:Restriction ;
       owl:cardinality "1"^^xsd:nonNegativeInteger ;
@@ -493,12 +511,12 @@ DSPCore:Library
   owl:equivalentClass [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:hasAntibody ;
+      owl:onProperty DSPCore:hasAssay ;
     ] ;
   owl:equivalentClass [
       a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:hasAssay ;
+      owl:minCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty prov:wasUsedBy ;
     ] ;
   skos:prefLabel "Library" ;
 .
@@ -666,11 +684,6 @@ DSPCore:SequenceFile
   owl:equivalentClass [
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:hasPercentAlignedReads ;
-    ] ;
-  owl:equivalentClass [
-      a owl:Restriction ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty DSPCore:hasPercentDuplicateFragments ;
     ] ;
   owl:equivalentClass [
@@ -682,11 +695,6 @@ DSPCore:SequenceFile
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty DSPCore:hasReadLength ;
-    ] ;
-  owl:equivalentClass [
-      a owl:Restriction ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:usedReferenceAssembly ;
     ] ;
   skos:prefLabel "SequenceFile" ;
 .
@@ -725,7 +733,7 @@ DSPCore:Sequencing
   owl:equivalentClass [
       a owl:Restriction ;
       owl:minCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:usesSample ;
+      owl:onProperty DSPCore:usedSample ;
     ] ;
   owl:equivalentClass [
       a owl:Restriction ;
@@ -1414,12 +1422,12 @@ DSPCore:usedReferenceAssembly
   rdfs:subPropertyOf prov:used ;
   skos:prefLabel "usedReferenceAssembly" ;
 .
-DSPCore:usesSample
+DSPCore:usedSample
   a owl:ObjectProperty ;
-  rdfs:label "usesSample" ;
+  rdfs:label "usedSample" ;
   rdfs:range DSPCore:BioSample ;
   rdfs:subPropertyOf prov:used ;
-  skos:prefLabel "usesSample" ;
+  skos:prefLabel "usedSample" ;
 .
 DSPCore:wasFundedBy
   a owl:ObjectProperty ;

--- a/src/extensions/epigenomics/Encode.ttl
+++ b/src/extensions/epigenomics/Encode.ttl
@@ -1,6 +1,5 @@
 # baseURI: http://datamodel.terra.bio/Encode
 # imports: http://datamodel.terra.bio/DSPCore
-# imports: http://datamodel.terra.bio/DSPdcat_ap
 # prefix: Encode
 
 @prefix : <http://datamodel.terra.bio/Encode#> .
@@ -108,7 +107,6 @@ DSPCore:hasAssayType
 <http://datamodel.terra.bio/Encode>
   a owl:Ontology ;
   owl:imports <http://datamodel.terra.bio/DSPCore> ;
-  owl:imports <http://datamodel.terra.bio/DSPdcat_ap> ;
   owl:versionInfo "Created with TopBraid Composer" ;
 .
 Encode:AuditFinding
@@ -152,7 +150,7 @@ Encode:ChIPSeq
   owl:equivalentClass [
       a owl:Restriction ;
       owl:cardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:usesSample ;
+      owl:onProperty DSPCore:usedSample ;
     ] ;
   owl:equivalentClass [
       a owl:Restriction ;

--- a/src/extensions/epigenomics/EncodeExamples.ttl
+++ b/src/extensions/epigenomics/EncodeExamples.ttl
@@ -178,7 +178,7 @@ EncodeExamples:ENCBS562VSE
   DSPCore:donatedBy EncodeExamples:ENCD0451RUA ;
   DSPCore:hasAnatomicalSite "http://purl.obolibrary.org/obo/UBERON_0002369"^^xsd:anyURI ;
   DSPCore:hasBioSampleType DSPCoreValueSets:Tissue ;
-  DSPCore:hasConsentCode DSPCore:NoRestriction ;
+  DSPdcat_ap:hasDataUseLimitation DSPCore:NoRestriction ;
   Encode:hasAward "http://encodeproject.org/awards/ENCODE"^^xsd:anyURI ;
   Encode:hasLab "http://encodeproject.org/labs/encode-consortium/"^^xsd:anyURI ;
   Encode:hasLifeStage "adult" ;
@@ -187,7 +187,6 @@ EncodeExamples:ENCBS562VSE
   Encode:wasPerturbed false ;
   dcterms:created "2015-04-21T22:38:19.753291+00:00" ;
   dcterms:isPartOf EncodeExamples:EncodeDataset ;
-  DSPdcat_ap:hasDataUseLimitation DSPCore:NoRestriction ;
   dcterms:source "http://www.encodeproject.org/sources/leidos/" ;
   rdfs:label "ENCBS562VSE" ;
   skos:prefLabel "ENCBS562VSE" ;
@@ -494,7 +493,7 @@ EncodeExamples:ENCLB011GAL
 EncodeExamples:ENCLB051VTH
   a DSPCore:Library ;
   DSPCore:hasCrossReference "http://encodeproject.org/libraries/ENCLB051VTH/" ;
-  DSPCore:usesSample EncodeExamples:ENCBS467KQD ;
+  DSPCore:usedSample EncodeExamples:ENCBS467KQD ;
   Encode:hasAward "http:encodeproject.org/awards/UM1HG009390/"^^xsd:anyURI ;
   Encode:hasLab "http://encodeproject.org/labs/bradley-bernstein/"^^xsd:anyURI ;
   Encode:hasLibraryMaterial "http://purl.obolibrary.org/obo/SO_0000352" ;
@@ -514,7 +513,7 @@ EncodeExamples:ENCLB793FWQ
   DSPCore:hasAntibody EncodeExamples:ENCAB000ADU ;
   DSPCore:hasCrossReference "GEO:GSM4250754" ;
   DSPCore:hasCrossReference "http://encodeproject.org/libraries/ENCLB793FWQ/" ;
-  DSPCore:usesSample EncodeExamples:ENCBS467KQD ;
+  DSPCore:usedSample EncodeExamples:ENCBS467KQD ;
   Encode:hasAward "http://encodeproject.org/awards/UM1HG009390/"^^xsd:anyURI ;
   Encode:hasLab "http://encodeproject.org/labs/bradley-bernstein/"^^xsd:anyURI ;
   Encode:hasLibraryMaterial "http://purl.obolibrary.org/obo/SO_0000352" ;
@@ -528,7 +527,7 @@ EncodeExamples:ENCLB793FWQ
 .
 EncodeExamples:ENCLB994HJD
   a DSPCore:Library ;
-  DSPCore:usesSample EncodeExamples:ENCBS420UOM ;
+  DSPCore:usedSample EncodeExamples:ENCBS420UOM ;
   Encode:hasSizeRange "<30" ;
   rdfs:label "ENCLB994HJD" ;
 .
@@ -538,7 +537,7 @@ EncodeExamples:ENCSR463NAD
 .
 EncodeExamples:ENCSR812FNU
   a Encode:Experiment ;
-  DSPCore:usesSample EncodeExamples:ENCBS389AUD ;
+  DSPCore:usedSample EncodeExamples:ENCBS389AUD ;
   Encode:hasAward "http://encodeproject.org/awards/U01HG007919"^^xsd:anyURI ;
   Encode:hasLab "http://encodeproject.org/awards/michael-snyder"^^xsd:anyURI ;
   dcterms:description "CTCF ChIP-seq on primary keratinocytes in day 6 of differentiation" ;
@@ -548,7 +547,7 @@ EncodeExamples:ENCSR895SFC
   a Encode:Experiment ;
   DSPCore:dateReleased "2016-08-01T00:00:00"^^xsd:dateTime ;
   DSPCore:hasCrossReference "http://www.encodeproject.org/experiments/ENCSR895SFC"^^dcterms:URI ;
-  DSPCore:usesSample EncodeExamples:ENCBS719AMH ;
+  DSPCore:usedSample EncodeExamples:ENCBS719AMH ;
   Encode:hasStatus "released" ;
   dcterms:created "2016-07-25T22:17:18.167352+00" ;
   dcterms:dateSubmitted "2016-07-31" ;
@@ -603,7 +602,7 @@ EncodeExamples:LibraryPrep_for_ENCLB051VTH
 .
 EncodeExamples:LibraryPrep_for_ENCLB793FWQ
   a DSPCore:LibraryPrep ;
-  DSPCore:usesSample EncodeExamples:ENCBS467KQD ;
+  DSPCore:usedSample EncodeExamples:ENCBS467KQD ;
   Encode:hasLab "http://encodeproject.org/labs/bradley-bernstein/"^^xsd:anyURI ;
   dcterms:created "2019-08-14T04:40:41.383274+00:00" ;
   rdfs:label "LibraryPrep_for_ENCLB793FWQ" ;


### PR DESCRIPTION
DSPCore Data Model 

	Cleanup

	--Changed import names per https://broadinstitute.atlassian.net/browse/DSPDC-918 

	--Removed extraneous import of PATO concept.

	--usesSample => usedSample to be consistent with prov ontology

	--Alignment Post Processing is essentially a Pipeline; subclassed it so that it can stay consistent with EpiLIMS 

	Cardinality..

	--Alignment files should use a software agent; must have 1 referenceAssembly, has at most one % aligned reads; possibly some data won’t have this.

	--AssayActivity does not use a library; library does not require an assay but should be usedBy some something.

	--SequenceFile does not have aligned reads or reference assembly

Encode

	--Restriction updated to capture usedSample

	--Removed unnecessary import

EncodeExamples

	usedSample, updated to catch up with DUO changes – replaced hasConsentCode with hasDataUseLimitation